### PR TITLE
fix: missing role permissions for deployments

### DIFF
--- a/charts/slack/values.yaml
+++ b/charts/slack/values.yaml
@@ -89,6 +89,12 @@ role:
         - get
         - update
     - apiGroups:
+        - apps
+      resources:
+        - deployments
+      verbs:
+        - get
+    - apiGroups:
         - slack.app.jenkins-x.io
       resources:
         - slackbots


### PR DESCRIPTION
since #25 we need to get the tide deployment, and the app won't start if it doesn't have the permissions